### PR TITLE
Fix support-vs-array index confusion in sampling and DEFM::simulate

### DIFF
--- a/include/barry/model-meat.hpp
+++ b/include/barry/model-meat.hpp
@@ -1642,7 +1642,13 @@ inline Array_Type Model<Array_Type,Data_Counter_Type, Data_Rule_Type, Data_Rule_
 
     // Making sure the powerset probabilities for this support are current
     // before sampling from them (mirrors the sample(size_t, params) path).
-    if (!first_calc_done[a] || !vec_equal_approx(params, params_last[a]))
+    // `pset_probs` may still be empty here: init() adds arrays without sizing
+    // it, and a prior likelihood() call sets first_calc_done/params_last
+    // without ever filling it. Guard against both so we never index into an
+    // unpopulated buffer.
+    if (pset_probs.empty() ||
+        !first_calc_done[a] ||
+        !vec_equal_approx(params, params_last[a]))
         update_pset_probs(params, 1u, static_cast<int>(a));
 
     // Sampling an array

--- a/include/barry/model-meat.hpp
+++ b/include/barry/model-meat.hpp
@@ -1627,65 +1627,33 @@ inline Array_Type Model<Array_Type,Data_Counter_Type, Data_Rule_Type, Data_Rule_
         // Retrieving the corresponding position in the support
         i = locator->second;
 
-    // Getting the index
-    size_t a = arrays2support[i];
-    
+    // Getting the support index. In the new-array branch above, `i` is an
+    // array index and must be resolved through `arrays2support`. In the
+    // reuse branch, `keys2support` already stores a SUPPORT index, so
+    // `locator->second` (assigned to `i`) is the support index directly and
+    // must NOT be mapped through `arrays2support` a second time.
+    size_t a = (locator == keys2support.end()) ?
+        arrays2support[i] : i;
+
     // Generating a random
     std::uniform_real_distribution<> urand(0, 1);
     double r = urand(*rengine);
     double cumprob = 0.0;
 
-    size_t k = params.size();
+    // Making sure the powerset probabilities for this support are current
+    // before sampling from them (mirrors the sample(size_t, params) path).
+    if (!first_calc_done[a] || !vec_equal_approx(params, params_last[a]))
+        update_pset_probs(params, 1u, static_cast<int>(a));
 
     // Sampling an array
     size_t j = 0u;
     double * probs = &pset_probs[ pset_locations[a] ];
-    if (first_calc_done[a] && (vec_equal_approx(params, params_last[a])))
-    // If precomputed, then no need to recalc support
-    {
+    while (cumprob < r)
+        cumprob += *(probs + j++);
 
-        while (cumprob < r)
-            cumprob += *(probs + j++);
+    if (j > 0u)
+        j--;
 
-        if (j > 0u)
-            j--;
-
-    } else { 
-       
-        // probs.resize(pset_arrays[a].size());
-        std::vector< double > temp_stats(params.size());
-        const double * stats = &pset_stats[pset_locations[a] * k];
-
-        int i_matches = -1;
-        for (size_t array = 0u; array < pset_sizes[a]; ++array)
-        {
-
-            // Filling out the parameters
-            for (auto p = 0u; p < params.size(); ++p)
-                temp_stats[p] = stats[array * k + p];
-
-            *(probs + array) = this->likelihood(params, temp_stats, i, false);
-            cumprob += *(probs + array);
-
-            if (i_matches == -1 && cumprob >= r)
-                i_matches = array;
-        }
-
-        #ifdef BARRY_DEBUG
-        if (i_matches < 0)
-            throw std::logic_error(
-                std::string(
-                    "Something went wrong when sampling from a different set of.") +
-                std::string("parameters. Please report this bug: ") +
-                std::string(" cumprob: ") + std::to_string(cumprob) +
-                std::string(" r: ") + std::to_string(r)
-                );
-        #endif
-
-        j = i_matches;
-        first_calc_done[a] = true;
-    }
-    
 
     #ifdef BARRY_DEBUG
     return this->pset_arrays.at(a).at(j);   

--- a/include/barry/models/defm/defm-meat.hpp
+++ b/include/barry/models/defm/defm-meat.hpp
@@ -41,9 +41,8 @@ inline void DEFM::simulate(
     int * y_out
 ) {
 
-    size_t model_num = 0u; 
+    size_t model_num = 0u;
     size_t n_entry = M_order * Y_ncol;
-    auto idx = this->get_arrays2support();
     DEFMArray last_array;
     for (size_t i = 0u; i < N; ++i)
     {
@@ -57,7 +56,11 @@ inline void DEFM::simulate(
             // In the first process, we take the data as is
             if (proc_n == 0u)
             {
-                last_array = this->sample(idx->at(model_num++), par);
+                // `model_num` is an array index; the sample(size_t, par)
+                // overload resolves it to a support internally. Passing
+                // idx->at(model_num) (a support index) would map it through
+                // arrays2support a second time and pick the wrong support.
+                last_array = this->sample(model_num++, par);
                 for (size_t y = 0u; y < Y_ncol; ++y)
                     *(y_out + n_entry++) = last_array(M_order, y, false);
 

--- a/tests/20-defm-simulate-torus.cpp
+++ b/tests/20-defm-simulate-torus.cpp
@@ -10,16 +10,26 @@
 // strong penalty on extra ones, the walk is deterministic, so every
 // simulated row must have exactly one active state that advances by one.
 //
-// Before the fix, the walk broke the first time a mid-simulation
-// conditioning state was revisited (row 13 in the README example): the
-// sampler resolved the reused support through arrays2support a second time
-// and drew from the wrong (all-zeros) support, collapsing the process.
+// Two individuals are simulated with *different* starting states. This
+// exercises both bugs the fix addresses:
+//
+//  - Model::sample(Array&): before the fix the walk broke the first time a
+//    mid-simulation conditioning state was revisited (row 13 in the README
+//    example); the reused support was mapped through arrays2support a second
+//    time and the sampler drew from the wrong (all-zeros) support.
+//
+//  - DEFM::simulate: the first process of the 2nd+ individual was sampled
+//    with a support index where an array index was expected, so a second
+//    individual starting in a distinct state took a wrong first step.
 
 BARRY_TEST_CASE("DEFM simulate torus keeps moving", "[DEFM simulate torus]") {
 
     using namespace defm;
 
-    const size_t n  = 20u;
+    const size_t per = 12u;               // rows per individual
+    const std::vector< size_t > starts = {0u, 3u}; // initial active state
+    const size_t nind = starts.size();
+    const size_t n  = per * nind;
     const size_t ny = 10u;
     const size_t nx = 1u;
 
@@ -27,8 +37,15 @@ BARRY_TEST_CASE("DEFM simulate torus keeps moving", "[DEFM simulate torus]") {
     std::vector< int >    y(n * ny, 0);
     std::vector< double > x(n * nx, 0.0);
 
-    // Column-major storage; the walk starts with y0 active.
-    y[0] = 1;
+    // One individual per block of `per` rows; each starts with its own state
+    // active. Storage is column-major: index(row, col) = row + col * n.
+    for (size_t k = 0u; k < nind; ++k)
+    {
+        size_t base_row = k * per;
+        for (size_t r = base_row; r < (k + 1u) * per; ++r)
+            id[r] = static_cast< int >(k) + 1;
+        y[base_row + starts[k] * n] = 1;
+    }
 
     DEFM model(&id[0], &y[0], &x[0], n, ny, nx, 1u, true, true);
 
@@ -52,31 +69,41 @@ BARRY_TEST_CASE("DEFM simulate torus keeps moving", "[DEFM simulate torus]") {
     std::vector< double > par(ny, 200.0);
     par.push_back(-20.0);
 
+    // simulate() only writes the sampled rows; the first (baseline) row of
+    // each individual is left untouched, so seed those for the assertions.
     std::vector< int > out(n * ny, 0);
-    out[0] = 1; // baseline row (simulate() only writes rows 2..n)
+    for (size_t k = 0u; k < nind; ++k)
+        out[(k * per) * ny + starts[k]] = 1;
 
     model.simulate(par, &out[0]);
 
-    // Each row must have exactly one active state, advancing by one.
+    // Within each individual, every row must have exactly one active state,
+    // advancing by one from that individual's starting state.
     bool ok = true;
-    for (size_t r = 0u; r < n; ++r)
+    for (size_t k = 0u; k < nind; ++k)
     {
-        size_t active     = ny;      // sentinel: "none"
-        size_t n_active   = 0u;
-        for (size_t c = 0u; c < ny; ++c)
-            if (out[r * ny + c] == 1)
-            {
-                active = c;
-                ++n_active;
-            }
-
-        size_t expected = r % ny;    // y0, y1, ..., y9, y0, ...
-        if ((n_active != 1u) || (active != expected))
+        for (size_t rr = 0u; rr < per; ++rr)
         {
-            ok = false;
-            std::cout << "Row " << (r + 1u) << ": expected single active state y"
-                      << expected << ", got " << n_active << " active (first at "
-                      << (active == ny ? -1 : static_cast<int>(active)) << ")\n";
+            size_t row       = k * per + rr;
+            size_t active    = ny;      // sentinel: "none"
+            size_t n_active  = 0u;
+            for (size_t c = 0u; c < ny; ++c)
+                if (out[row * ny + c] == 1)
+                {
+                    active = c;
+                    ++n_active;
+                }
+
+            size_t expected = (starts[k] + rr) % ny;
+            if ((n_active != 1u) || (active != expected))
+            {
+                ok = false;
+                std::cout << "Individual " << (k + 1u) << ", row " << (rr + 1u)
+                          << ": expected single active state y" << expected
+                          << ", got " << n_active << " active (first at "
+                          << (active == ny ? -1 : static_cast<int>(active))
+                          << ")\n";
+            }
         }
     }
 

--- a/tests/20-defm-simulate-torus.cpp
+++ b/tests/20-defm-simulate-torus.cpp
@@ -1,0 +1,92 @@
+#include "tests.hpp"
+#include "../include/barry/models/defm.hpp"
+
+// Regression test for the support-vs-array index confusion in
+// Model::sample(const Array_Type &, params) and DEFM::simulate().
+//
+// The model describes a "torus" walk over ten mutually-exclusive states:
+// the single active state y_k deterministically moves to y_{k+1}, wrapping
+// around from y9 back to y0. With a strong reward on each transition and a
+// strong penalty on extra ones, the walk is deterministic, so every
+// simulated row must have exactly one active state that advances by one.
+//
+// Before the fix, the walk broke the first time a mid-simulation
+// conditioning state was revisited (row 13 in the README example): the
+// sampler resolved the reused support through arrays2support a second time
+// and drew from the wrong (all-zeros) support, collapsing the process.
+
+BARRY_TEST_CASE("DEFM simulate torus keeps moving", "[DEFM simulate torus]") {
+
+    using namespace defm;
+
+    const size_t n  = 20u;
+    const size_t ny = 10u;
+    const size_t nx = 1u;
+
+    std::vector< int >    id(n, 1);
+    std::vector< int >    y(n * ny, 0);
+    std::vector< double > x(n * nx, 0.0);
+
+    // Column-major storage; the walk starts with y0 active.
+    y[0] = 1;
+
+    DEFM model(&id[0], &y[0], &x[0], n, ny, nx, 1u, true, true);
+
+    // Ten transition terms: y_i -> y_{i+1}, wrapping at the end.
+    for (size_t i = 0u; i < (ny - 1u); ++i)
+    {
+        std::string f =
+            "{y"  + std::to_string(i) + ", 0y" + std::to_string(i + 1u) +
+            "} > {0y" + std::to_string(i) + ", y"  + std::to_string(i + 1u) + "}";
+        counter_formula(model.get_counters(), f, 1u, ny);
+    }
+    counter_formula(model.get_counters(), "{0y0, y9} > {y0, 0y9}", 1u, ny);
+
+    counter_ones(model.get_counters());
+
+    model.init(false);
+    model.set_seed(33);
+
+    // Strong transition reward, strong ones penalty => deterministic torus
+    // (independent of the RNG, so the assertions are portable).
+    std::vector< double > par(ny, 200.0);
+    par.push_back(-20.0);
+
+    std::vector< int > out(n * ny, 0);
+    out[0] = 1; // baseline row (simulate() only writes rows 2..n)
+
+    model.simulate(par, &out[0]);
+
+    // Each row must have exactly one active state, advancing by one.
+    bool ok = true;
+    for (size_t r = 0u; r < n; ++r)
+    {
+        size_t active     = ny;      // sentinel: "none"
+        size_t n_active   = 0u;
+        for (size_t c = 0u; c < ny; ++c)
+            if (out[r * ny + c] == 1)
+            {
+                active = c;
+                ++n_active;
+            }
+
+        size_t expected = r % ny;    // y0, y1, ..., y9, y0, ...
+        if ((n_active != 1u) || (active != expected))
+        {
+            ok = false;
+            std::cout << "Row " << (r + 1u) << ": expected single active state y"
+                      << expected << ", got " << n_active << " active (first at "
+                      << (active == ny ? -1 : static_cast<int>(active)) << ")\n";
+        }
+    }
+
+    #ifdef CATCH_CONFIG_MAIN
+    REQUIRE(ok);
+    #else
+    if (!ok)
+        std::cout << "FAIL: torus walk did not advance as expected." << std::endl;
+    else
+        std::cout << "OK: torus walk advanced through all rows." << std::endl;
+    #endif
+
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -29,3 +29,4 @@
 #include "16b-defm-counts-with-formulas.cpp"
 #include "17-defm-likelihood.cpp"
 #include "18-defm-counter-names.cpp"
+#include "20-defm-simulate-torus.cpp"


### PR DESCRIPTION
## Summary

Fixes a sampling bug where a simulated Markov/DEFM process would collapse the first time a conditioning state discovered *mid-simulation* was revisited. In the `defm` README "Example 2: A fun model" (a 10-state torus walk), the active state advances correctly through row 12 but breaks at **row 13** and never recovers.

Root cause is a support-index / array-index mix-up in two places:

1. **`Model::sample(const Array_Type &, params)`** — `keys2support` maps a hash key to a **support index**, but the reuse branch assigned `i = locator->second` (already a support index) and then computed `a = arrays2support[i]`, mapping it through `arrays2support` a *second* time. So reusing a known conditioning state selected an unrelated support. The two "correct" rows in the README output were coincidences (a support index that happened to be a valid array index mapping back to the same support).

2. **`DEFM::simulate`** — the mirror-image bug: the first process of each individual was sampled with `sample(idx->at(model_num++), par)`, i.e. `arrays2support[model_num]` (a support index) passed to the `sample(size_t, params)` overload, which itself expects an **array index** and resolves it through `arrays2support`. This gives wrong first-row draws for the 2nd+ individuals in a multi-individual simulation.

## Fix

Key on the support index directly in both places. The `Array_Type` overload now delegates probability computation to `update_pset_probs(params, 1u, a)`, matching the existing `sample(size_t, params)` path and removing the duplicated recompute loop (which carried the same index confusion into its own `likelihood(..., i, ...)` call).

## Tests

Adds `tests/20-defm-simulate-torus.cpp`: a deterministic 10-state torus walk (strong transition reward + strong ones penalty, so the outcome is RNG-independent and portable). It asserts every simulated row has exactly one active state advancing by one and wrapping y9→y0.

- Fails on the old code (walk collapses at row 13).
- Passes with this fix.
- Full suite: `109 assertions in 21 test cases`, all passing.

Verified against the `defm` README Example 2 (single individual) and a two-individual case where the second individual starts in a distinct state — both now walk the torus correctly for all rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
